### PR TITLE
Fix a warning under MSVC

### DIFF
--- a/include/boost/format/parsing.hpp
+++ b/include/boost/format/parsing.hpp
@@ -50,7 +50,7 @@ namespace detail {
 # else
         (void) fac;     // remove "unused parameter" warning
         using namespace std;
-        return isdigit(c); 
+        return isdigit(c) != 0; 
 #endif 
     }
  


### PR DESCRIPTION
Fix a warning under MSVC when BOOST_NO_STD_LOCALE is defined.