### PR TITLE
"less" to "fewer"

### DIFF
--- a/include/boost/format/exceptions.hpp
+++ b/include/boost/format/exceptions.hpp
@@ -73,7 +73,7 @@ namespace boost {
             std::size_t get_expected() const { return expected_; }
             virtual const char *what() const throw() {
                 return "boost::too_many_args: "
-                    "format-string referred to less arguments than were passed";
+                    "format-string referred to fewer arguments than were passed";
             }
         };
 


### PR DESCRIPTION
"Fewer" is the word used for discrete objects, while "less" is used for continuous amounts. As you cannot have part of an argument, "fewer" is the appropriate word here.