### PR TITLE
Master had an additional commit not in develop

### DIFF
--- a/include/boost/format/exceptions.hpp
+++ b/include/boost/format/exceptions.hpp
@@ -73,7 +73,7 @@ namespace boost {
             std::size_t get_expected() const { return expected_; }
             virtual const char *what() const throw() {
                 return "boost::too_many_args: "
-                    "format-string referred to less arguments than were passed";
+                    "format-string referred to fewer arguments than were passed";
             }
         };
 


### PR DESCRIPTION
Changed 'less' to 'fewer' in an error message. Patch from @tempoz

I found a commit in boost format master branch not in develop:
```
jking@ubuntu:~/boost/libs/format$ git checkout master
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
jking@ubuntu:~/boost/libs/format$ git blame include/boost/format/exceptions.hpp | grep '  7'
0fde2d2b (Gennaro Prota 2006-07-20 13:36:16 +0000   7) // Distributed under the Boost Software License, Version 1.0.
18785faa (Samuel Krempp 2004-01-24 17:33:18 +0000  70)             too_many_args(std::size_t cur, std::size_t expected) 
18785faa (Samuel Krempp 2004-01-24 17:33:18 +0000  71)                 : cur_(cur), expected_(expected) {}
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  72)             std::size_t get_cur() const { return cur_; }
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  73)             std::size_t get_expected() const { return expected_; }
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  74)             virtual const char *what() const throw() {
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  75)                 return "boost::too_many_args: "
d8053752 (Marshall Clow 2015-05-18 08:34:53 -0700  76)                     "format-string referred to fewer arguments than were passed";
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  77)             }
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  78)         };
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  79) 

jking@ubuntu:~/boost/libs/format$ git checkout develop
Switched to branch 'develop'
Your branch is up-to-date with 'origin/develop'.
jking@ubuntu:~/boost/libs/format$ git blame include/boost/format/exceptions.hpp | grep '  7'
fe2c3f37 (Gennaro Prota 2006-07-20 12:13:16 +0000   7) // Distributed under the Boost Software License, Version 1.0.
18785faa (Samuel Krempp 2004-01-24 17:33:18 +0000  70)             too_many_args(std::size_t cur, std::size_t expected) 
18785faa (Samuel Krempp 2004-01-24 17:33:18 +0000  71)                 : cur_(cur), expected_(expected) {}
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  72)             std::size_t get_cur() const { return cur_; }
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  73)             std::size_t get_expected() const { return expected_; }
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  74)             virtual const char *what() const throw() {
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  75)                 return "boost::too_many_args: "
fe2c3f37 (Gennaro Prota 2006-07-20 12:13:16 +0000  76)                     "format-string referred to less arguments than were passed";
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  77)             }
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  78)         };
beb10ca1 (Samuel Krempp 2004-01-21 11:51:23 +0000  79) 

jking@ubuntu:~/boost/libs/format$ git show d8053752
commit d80537520b8aeaa51271acfd2eeb3c6a522fb04e
Author: Marshall Clow <marshall@idio.com>
Date:   Mon May 18 08:34:53 2015 -0700

    Changed 'less' to 'fewer' in an error message. Patch from @tempoz

diff --git a/include/boost/format/exceptions.hpp b/include/boost/format/exceptions.hpp
index 9b2de83..56ee30d 100644
--- a/include/boost/format/exceptions.hpp
+++ b/include/boost/format/exceptions.hpp
@@ -73,7 +73,7 @@ namespace boost {
             std::size_t get_expected() const { return expected_; }
             virtual const char *what() const throw() {
                 return "boost::too_many_args: "
-                    "format-string referred to less arguments than were passed";
+                    "format-string referred to fewer arguments than were passed";
             }
         };
```

