### PR TITLE
Add appveyor and travis build scripts for continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,272 @@
+# Copyright 2016 Peter Dimov
+# Copyright 2017 James E. King, III
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
+#
+# Generic Travis CI build script
+# For instructions on setting up your own fork and running CI builds before submitting
+# your changes into the official repository, see:
+# https://svn.boost.org/trac10/wiki/TravisCoverals
+#
+# Workflow:
+# Follow the instructions above.
+# Make sure your develop branch is synchronized with upstream.
+# Submit a pull request into your fork's develop.
+# Watch Travis CI build your change under a variety of compilers and language levels.
+#
+# Instructions for customizing this script for your library:
+# 
+# 1. Choose which compiler and language level combinations you want to run and
+#    uncomment them.
+# 2. Update the global B2 environment settings to your liking.
+# 3. If your project builds a library (is not header-only) you can get coveralls
+#    code coverage analysis by uncommenting the coverage job and copying the
+#    compute/.coveralls.yml file into your repository.
+#
+# That's it - the script will do everything else for you.
+
+language: cpp
+
+sudo: false
+dist: trusty
+
+os:
+  - linux
+  - osx
+
+branches:
+  only:
+    - develop
+    - master
+
+env:
+  global:
+    # see: http://www.boost.org/build/doc/html/bbv2/overview/invocation.html#bbv2.overview.invocation.properties
+    # to use the default for a given environment, comment it out; recommend you build debug and release however..
+    # - B2_ADDRESS_MODEL=address-model=64,32
+    # - B2_LINK=link=shared,static
+    # - B2_THREADING=threading=multi,single
+    - B2_VARIANT=variant=release,debug
+
+  matrix:
+    # This disables all built-in matrix build generation.
+    # We'll be specific about compilers and options.
+    - BOGUS_JOB=true
+
+addons:
+  apt:
+    packages:
+      - binutils-gold
+      - gdb
+      - libc6-dbg
+    
+matrix:
+  allow_failures:
+    - env: MAYFAIL=true
+
+  exclude:
+    - env: BOGUS_JOB=true
+
+  include:
+    # C++03 using a very old compiler
+    - os: linux
+      env: COMMENT="c++03 gcc-4.8" TOOLSET=gcc COMPILER=g++-4.8 CXXSTD=c++03
+    # and new ones
+    - os: linux
+      env: COMMENT="c++03 gcc-7" TOOLSET=gcc COMPILER=g++-7 CXXSTD=c++03
+      addons:
+        apt:
+          packages:
+           - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+    - os: linux
+      env: COMMENT="c++03 clang-5.0" TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=c++03
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+            - g++-7
+          sources:
+            - llvm-toolchain-trusty-5.0
+            - ubuntu-toolchain-r-test
+    - os: linux
+      env: COMMENT="c++11 clang-5.0" TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=c++11
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+            - g++-7
+          sources:
+            - llvm-toolchain-trusty-5.0
+            - ubuntu-toolchain-r-test
+    - os: linux
+      env: COMMENT="c++14 clang-5.0" TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=c++14
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+            - g++-7
+          sources:
+            - llvm-toolchain-trusty-5.0
+            - ubuntu-toolchain-r-test
+    - os: linux
+      env: COMMENT="c++17 clang-5.0" TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=c++17
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+            - g++-7
+          sources:
+            - llvm-toolchain-trusty-5.0
+            - ubuntu-toolchain-r-test
+
+    # UBSAN build
+    - os: linux
+      env: COMMENT="ubsan clang-5.0" B2_VARIANT="variant=debug" TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=c++03 CXXFLAGS="cxxflags=-fno-omit-frame-pointer cxxflags=-fsanitize=undefined cxxflags=-fsanitize=integer" LINKFLAGS="linkflags=-fsanitize=undefined"
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+            - g++-7
+          sources:
+            - llvm-toolchain-trusty-5.0
+            - ubuntu-toolchain-r-test
+
+    - os: osx
+      osx_image: xcode8
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=c++03
+
+    - os: osx
+      osx_image: xcode9.1
+      env: TOOLSET=clang COMPILER=clang++ CXXSTD=c++03
+
+    # Coverage build - for projects that build a library
+    # - os: linux
+    #   env: COMMENT="code coverage" TOOLSET=gcc COMPILER=g++-6 CXXSTD=c++11 B2_VARIANT="variant=profile" CXXFLAGS="cxxflags=--coverage" LINKFLAGS="linkflags=--coverage" COVERALL=1
+    #   addons:
+    #     apt:
+    #       packages:
+    #         - g++-6
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+
+    ### other archived configurations for reference
+    # C++11 using older compilers
+    # - os: linux
+    #   env: COMMENT="c++11 gcc-5" TOOLSET=gcc COMPILER=g++-5 CXXSTD=c++11
+    #   addons:
+    #     apt:
+    #       packages:
+    #         - g++-5
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    # - os: linux
+    #   env: COMMENT="c++11 clang-3.8" TOOLSET=clang COMPILER=clang++-3.8 CXXSTD=c++11
+    #   addons:
+    #     apt:
+    #       packages:
+    #         - clang-3.8
+    #         - g++-5
+    #       sources:
+    #         - llvm-toolchain-trusty-3.8
+    #         - ubuntu-toolchain-r-test
+
+    # C++14 using recent compilers
+    # - os: linux
+    #   env: COMMENT="c++14 gcc-6" TOOLSET=gcc COMPILER=g++-6 CXXSTD=c++14
+    #   addons:
+    #     apt:
+    #       packages:
+    #         - g++-6
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    # - os: linux
+    #   env: COMMENT="c++14 clang-4.0" TOOLSET=clang COMPILER=clang++-4.0 CXXSTD=c++14
+    #   addons:
+    #     apt:
+    #       packages:
+    #         - clang-4.0
+    #         - g++-6
+    #       sources:
+    #         - llvm-toolchain-trusty-4.0
+    #         - ubuntu-toolchain-r-test
+
+    # C++17 using the latest compilers
+    # - os: linux
+    #   env: COMMENT="c++17 gcc-7" TOOLSET=gcc COMPILER=g++-7 CXXSTD=c++17
+    #   addons:
+    #     apt:
+    #       packages:
+    #        - g++-7
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    # - os: linux
+    #   env: COMMENT="c++17 clang-5.0" TOOLSET=clang COMPILER=clang++-5.0 CXXSTD=c++17
+    #   addons:
+    #     apt:
+    #       packages:
+    #         - clang-5.0
+    #         - g++-7
+    #       sources:
+    #         - llvm-toolchain-trusty-5.0
+    #         - ubuntu-toolchain-r-test
+
+    # - os: osx
+    #   osx_image: xcode8.3
+    #   env: TOOLSET=clang COMPILER=clang++ CXXSTD=c++11
+
+    # - os: osx
+    #   osx_image: xcode9
+    #   env: TOOLSET=clang COMPILER=clang++ CXXSTD=c++14
+
+
+install:
+  - export SELF=`basename $TRAVIS_BUILD_DIR`
+  - cd ..
+  - git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+  - cd boost-root
+  - git submodule update --init tools/boostdep
+  - git submodule update --init tools/build
+  - git submodule update --init tools/inspect
+  - cp -r $TRAVIS_BUILD_DIR/* libs/$SELF
+  - export BOOST_ROOT="`pwd`"
+  - export PATH="`pwd`":$PATH 
+  - python tools/boostdep/depinst/depinst.py $SELF
+  - ./bootstrap.sh
+  - ./b2 headers
+
+script:
+  - export COMPILER_VERSION=`$COMPILER --version`
+  - |-
+    echo "using $TOOLSET : : $COMPILER : <cxxflags>-std=$CXXSTD ;" > ~/user-config.jam
+  - |-
+    echo "[**] COMPILER: $COMPILER_VERSION [**]"
+  - |-
+    echo "./b2 libs/$SELF/test toolset=$TOOLSET $CXXFLAGS $DEFINES $LINKFLAGS $B2_ADDRESS_MODEL $B2_LINK $B2_THREADING $B2_VARIANT -j3"
+  - ./b2 libs/$SELF/test toolset=$TOOLSET $CXXFLAGS $DEFINES $LINKFLAGS $B2_ADDRESS_MODEL $B2_LINK $B2_THREADING $B2_VARIANT -j3
+
+after_success:
+  # If this is not a profiling build skip the rest...
+  - if [[ "$COVERALL" -ne "1" ]]; then exit 0; fi
+
+  # Copying Coveralls data to a separate folder
+  - wget https://github.com/linux-test-project/lcov/archive/v1.13.zip
+  - unzip v1.13.zip
+  - LCOV="`pwd`/lcov-1.13/bin/lcov --gcov-tool gcov-6"
+
+  # Preparing Coveralls data
+  - mkdir -p $TRAVIS_BUILD_DIR/coverals
+  - $LCOV --directory bin.v2/libs/$SELF --base-directory libs/$SELF --capture --output-file $TRAVIS_BUILD_DIR/coverals/coverage.info --no-external
+  - $LCOV --remove $TRAVIS_BUILD_DIR/coverals/coverage.info "*/$SELF/test/*" --output-file $TRAVIS_BUILD_DIR/coverals/coverage-filtered.info
+
+  # Sending data to Coveralls
+  - cd $TRAVIS_BUILD_DIR
+  - gem install coveralls-lcov
+  - coveralls-lcov coverals/coverage-filtered.info
+
+notifications:
+  email:
+    false
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,97 @@
+# Copyright 2016, 2017 Peter Dimov
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
+# When copying this to a new library, be sure to update the name of the library
+# in two places (once each at the top of install: and test_script:)
+
+version: 1.0.{build}-{branch}
+
+shallow_clone: true
+
+branches:
+  only:
+    - develop
+    - master
+
+matrix:
+  allow_failures:
+    - MAYFAIL: true
+
+environment:
+  global:
+    # see: http://www.boost.org/build/doc/html/bbv2/overview/invocation.html#bbv2.overview.invocation.properties
+    # to use the default for a given environment, comment it out; recommend you build debug and release however..
+    # on Windows it is important to exercise all the possibilities, especially shared vs static
+    # B2_ADDRESS_MODEL: address-model=64,32
+    # B2_LINK: link=shared,static
+    # B2_THREADING: threading=multi,single
+    B2_VARIANT: variant=release,debug
+
+  matrix:
+    - COMMENT: Visual Studio 2010
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      TOOLSET: msvc-10.0
+    - COMMENT: Visual Studio 2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      TOOLSET: msvc-14.1
+  # - COMMENT: cygwin (32-bit)
+  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  #   ADDPATH: C:\cygwin\bin;
+  #   B2_ADDRESS_MODEL: address-model=32
+  #   TOOLSET: gcc
+  #   CXXFLAGS: cxxflags=-std=c++03
+  #   MAYFAIL: true
+  #   BECAUSE: https://svn.boost.org/trac10/ticket/13249
+  # - COMMENT: cygwin (64-bit)
+  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+  #   ADDPATH: C:\cygwin64\bin;
+  #   B2_ADDRESS_MODEL: address-model=64
+  #   TOOLSET: gcc
+  #   CXXFLAGS: cxxflags=-std=c++03
+  #   MAYFAIL: true
+  #   BECAUSE: https://svn.boost.org/trac10/ticket/13249
+  # - COMMENT: mingw
+  #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+  #   ADDPATH: C:\mingw\bin;
+  #   B2_ADDRESS_MODEL: address-model=32
+  #   TOOLSET: gcc
+  #   CXXFLAGS: cxxflags=-std=c++03
+  #   MAYFAIL: true
+  #   BECAUSE: https://svn.boost.org/trac10/ticket/13255
+    - COMMENT: mingw-w64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;
+      B2_ADDRESS_MODEL: address-model=64
+      TOOLSET: gcc
+      CXXFLAGS: cxxflags=-std=c++03
+
+### other builds for reference..
+  # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+  #   TOOLSET: msvc-11.0
+  #   COMMENT: Visual Studio 2012
+  # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+  #   TOOLSET: msvc-12.0
+  #   COMMENT: Visual Studio 2013
+  # - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+  #   TOOLSET: msvc-14.0
+
+install:
+  - set SELF=format
+  - cd ..
+  - git clone -b %APPVEYOR_REPO_BRANCH% --depth 1 https://github.com/boostorg/boost.git boost-root
+  - cd boost-root
+  - git submodule update --init tools/boostdep
+  - git submodule update --init tools/build
+  - git submodule update --init tools/inspect
+  - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\%SELF%
+  - python tools/boostdep/depinst/depinst.py %SELF%
+  - cmd /c bootstrap
+  - b2 headers
+
+build: off
+
+test_script:
+  - set SELF=format
+  - PATH=%ADDPATH%%PATH%
+  - b2 libs/%SELF%/test toolset=%TOOLSET% %CXXFLAGS% %DEFINES% %B2_ADDRESS_MODEL% %B2_LINK% %B2_THREADING% %B2_VARIANT% -j3


### PR DESCRIPTION
### Results ###

Appveyor: https://ci.appveyor.com/project/jeking3/format/build/1.0.2-develop
Travis: https://travis-ci.org/jeking3/format/builds/286199980

### Known Issues ###

The following builds are commented out because of issues in this or other modules:

| ticket | module | issue |
| - | - | - |
| [13249](https://svn.boost.org/trac10/ticket/13249) | test | cygwin build on appveyor fails attempting to use linux calls |
| [13255](https://svn.boost.org/trac10/ticket/13255) | test | mingw build on appveyor uses undefined vsnprintf |

These should be investigated, fixed, and tests re-enabled.

### Maintainer Follow-Up ###

Maintainer of Boost.Format needs to request admin access on github, travis, and appveyor so that they can enable automatic builds on pull requests to the official repository.

A readme file should also be added with build results, similar to Boost.Uuid.