### PR TITLE
trac-4636: explicit clamping provided to ensure MSVC /RTCc succeeds

### DIFF
--- a/include/boost/format/feed_args.hpp
+++ b/include/boost/format/feed_args.hpp
@@ -200,7 +200,7 @@ namespace detail {
                    (res_beg[0] !=oss.widen('+') && res_beg[0] !=oss.widen('-')  ))
                     prefix_space = oss.widen(' ');
             size_type res_size = (std::min)(
-                static_cast<size_type>(specs.truncate_ - !!prefix_space), 
+                (static_cast<size_type>((specs.truncate_ & std::numeric_limits<size_type>::max())) - !!prefix_space), 
                 buf.pcount() );
             mk_str(res, res_beg, res_size, w, oss.fill(), fl, 
                    prefix_space, (specs.pad_scheme_ & format_item_t::centered) !=0 );
@@ -244,9 +244,9 @@ namespace detail {
                 }
                 // we now have the minimal-length output
                 const Ch * tmp_beg = buf.pbase();
-                size_type tmp_size = (std::min)(static_cast<size_type>(specs.truncate_),
-                                                buf.pcount() );
-                                                    
+                size_type tmp_size = (std::min)(
+                    (static_cast<size_type>(specs.truncate_ & std::numeric_limits<size_type>::max())),
+                    buf.pcount());
                 
                 if(static_cast<size_type>(w) <= tmp_size) { 
                     // minimal length is already >= w, so no padding (cool!)


### PR DESCRIPTION
This resolves a boost trac issue that has been open for 7 years!

Appveyor: https://ci.appveyor.com/project/jeking3/format/build/1.0.5-develop
Travis: https://travis-ci.org/jeking3/format/builds/286796222