### PR TITLE
trac-10324: const correctness on casts

### DIFF
--- a/include/boost/format/feed_args.hpp
+++ b/include/boost/format/feed_args.hpp
@@ -118,12 +118,12 @@ namespace detail {
 
     template< class Ch, class Tr, class T>
     void call_put_head(BOOST_IO_STD basic_ostream<Ch, Tr> & os, const void* x) {
-        put_head(os, *(typename ::boost::remove_reference<T>::type*)x);
+        put_head(os, *(typename ::boost::remove_reference<const T>::type*)x);
     }
 
     template< class Ch, class Tr, class T>
     void call_put_last(BOOST_IO_STD basic_ostream<Ch, Tr> & os, const void* x) {
-        put_last(os, *(T*)x);
+        put_last(os, *(const T*)x);
     }
 
     template< class Ch, class Tr>


### PR DESCRIPTION
I built this in my fork which can do CI builds:

PR: https://github.com/jeking3/format/pull/6/files
Appveyor: https://ci.appveyor.com/project/jeking3/format/build/1.0.10-develop
Travis: https://travis-ci.org/jeking3/format/builds/287176196