### PR TITLE
re-enable benchmark build as part of standard builds,

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -245,7 +245,7 @@ script:
     echo "[**] COMPILER: $COMPILER_VERSION [**]"
   - |-
     echo "./b2 libs/$SELF/test toolset=$TOOLSET $CXXFLAGS $DEFINES $LINKFLAGS $B2_ADDRESS_MODEL $B2_LINK $B2_THREADING $B2_VARIANT -j3"
-  - ./b2 libs/$SELF/test toolset=$TOOLSET $CXXFLAGS $DEFINES $LINKFLAGS $B2_ADDRESS_MODEL $B2_LINK $B2_THREADING $B2_VARIANT -j3
+  - ./b2 libs/$SELF toolset=$TOOLSET $CXXFLAGS $DEFINES $LINKFLAGS $B2_ADDRESS_MODEL $B2_LINK $B2_THREADING $B2_VARIANT -j3
 
 after_success:
   # If this is not a profiling build skip the rest...

--- a/Jamfile
+++ b/Jamfile
@@ -6,8 +6,21 @@
 #  Boost Software License, Version 1.0. (See accompanying file
 #  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-project libs/format ;
+project libs/format 
+    : requirements
+
+      <warnings>all
+
+      <toolset>clang:<cxxflags>-Wextra
+      <toolset>clang:<cxxflags>-ansi
+      <toolset>clang:<cxxflags>-pedantic
+
+      <toolset>gcc:<cxxflags>-Wextra
+      <toolset>gcc:<cxxflags>-ansi
+      <toolset>gcc:<cxxflags>-pedantic
+    ;
 
 # please order by name to ease maintenance
+build-project benchmark ;
 build-project example ;
 build-project test ;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,4 +94,4 @@ build: off
 test_script:
   - set SELF=format
   - PATH=%ADDPATH%%PATH%
-  - b2 libs/%SELF%/test toolset=%TOOLSET% %CXXFLAGS% %DEFINES% %B2_ADDRESS_MODEL% %B2_LINK% %B2_THREADING% %B2_VARIANT% -j3
+  - b2 libs/%SELF% toolset=%TOOLSET% %CXXFLAGS% %DEFINES% %B2_ADDRESS_MODEL% %B2_LINK% %B2_THREADING% %B2_VARIANT% -j3

--- a/benchmark/Jamfile
+++ b/benchmark/Jamfile
@@ -1,9 +1,12 @@
-#  Boost.Bind Library test Jamfile
+#  Boost.Format Library benchmark Jamfile
 #
 #  Copyright (c) 2003 Samuel Krempp
 #
 #  Distributed under the Boost Software License, Version 1.0.
 #  See www.boost.org/LICENSE_1_0.txt
+#
+
+project libs/format/benchmark ;
 
 exe bench_format_no_locale
     : bench_format.cpp

--- a/example/Jamfile
+++ b/example/Jamfile
@@ -18,6 +18,7 @@ exe sample_advanced
 
 exe sample_new_features
     : sample_new_features.cpp
+    : <toolset>clang:<cxxflags>-Wno-invalid-source-encoding
     ;
 
 exe sample_userType

--- a/include/boost/format/feed_args.hpp
+++ b/include/boost/format/feed_args.hpp
@@ -173,9 +173,11 @@ namespace detail {
 
         basic_oaltstringstream<Ch, Tr, Alloc>  oss( &buf);
 
+#if !defined(BOOST_NO_STD_LOCALE)
         if(loc_p != NULL)
             oss.imbue(*loc_p);
-        
+#endif
+
         specs.fmtstate_.apply_on(oss, loc_p);
 
         // the stream format state can be modified by manipulators in the argument :

--- a/include/boost/format/internals.hpp
+++ b/include/boost/format/internals.hpp
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <boost/assert.hpp>
+#include <boost/core/ignore_unused.hpp>
 #include <boost/optional.hpp>
 #include <boost/limits.hpp>
 #include <boost/format/detail/compat_workarounds.hpp>
@@ -111,7 +112,7 @@ namespace detail {
         else if(loc_default)
             os.imbue(*loc_default);
 #else
-        (void) loc_default; // keep compiler quiet if we don't support locales
+        ignore_unused(loc_default);
 #endif        
         // set the state of this stream according to our params
         if(width_ != -1)

--- a/include/boost/format/parsing.hpp
+++ b/include/boost/format/parsing.hpp
@@ -20,6 +20,7 @@
 #include <boost/throw_exception.hpp>
 #include <boost/assert.hpp>
 #include <boost/config.hpp>
+#include <boost/core/ignore_unused.hpp>
 
 
 namespace boost {
@@ -49,7 +50,7 @@ namespace detail {
 #if ! defined( BOOST_NO_LOCALE_ISDIGIT )
         return fac.is(std::ctype<Ch>::digit, c);
 # else
-        (void) fac;     // remove "unused parameter" warning
+        ignore_unused(fac);
         using namespace std;
         return isdigit(c) != 0; 
 #endif 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -11,15 +11,13 @@ project
     ;
 
 import testing ;
-{
 
 test-suite "format"
    :    [ run format_test1.cpp ]
         [ run format_test2.cpp ]
         [ run format_test3.cpp ]
         [ run format_test_wstring.cpp ]
-        [ run format_test_enum.cpp ]
+        [ run format_test_enum.cpp : : : <toolset>clang:<cxxflags>-Wno-unnamed-type-template-args ]
         [ run format_test_exceptions.cpp ]
-  ;
-}
+   ;
 


### PR DESCRIPTION
fixed a NO_LOCALE build error the benchmark build discovered,
updated ignored argument handling and fixed build warnings in clang,
changed CI build scripts to build from top level of library

Fork PR (to generate builds): https://github.com/jeking3/format/pull/7
Appveyor: https://ci.appveyor.com/project/jeking3/format/build/1.0.13-develop
Travis: https://travis-ci.org/jeking3/format/builds/287637375