### PR TITLE
Add conversion specifier support for 'A', 'a', and 'F'

### DIFF
--- a/doc/format.html
+++ b/doc/format.html
@@ -500,6 +500,14 @@ Jean, de Lattre de Tassigny,            +33 (0) 987 654 321
           </tr>
 
           <tr>
+            <td><b>a</b></td>
+
+            <td>hexadecimal exponent notation</td>
+
+            <td>sets floatfield bits to <i>scientific</i> | <i>fixed</i> (which is equivalent to <i>hexfloat</i>)</td>
+          </tr>
+
+          <tr>
             <td><b>e</b></td>
 
             <td>scientific float format</td>
@@ -524,13 +532,13 @@ Jean, de Lattre de Tassigny,            +33 (0) 987 654 321
           </tr>
 
           <tr>
-            <td><b>X, E</b> or <b>G</b></td>
+            <td><b>X, A, E, F</b> or <b>G</b></td>
 
             <td>same effect as their lowercase counterparts, but using
             uppercase letters for number outputs. (exponents, hex digits,
             ..)</td>
 
-            <td>same effects as <i>'x'</i>, <i>'e'</i>, or <i>'g'</i>,
+            <td>same effects as <i>'x'</i>, <i>'a'</i>, <i>'e'</i>, <i>'f'</i>, or <i>'g'</i> respectively,
             <b>plus</b> <i>uppercase</i></td>
           </tr>
 
@@ -1018,7 +1026,7 @@ std::basic_string&lt;charT,Traits&gt;  str(const basic_format&lt;charT,Traits&gt
   height="31" width="88"></a></p>
 
   <p>Revised 
-  <!--webbot bot="Timestamp" s-type="EDITED" s-format="%d %B, %Y" startspan -->02 December, 2006<!--webbot bot="Timestamp" endspan i-checksum="38510" --></p>
+  <!--webbot bot="Timestamp" s-type="EDITED" s-format="%d %B, %Y" startspan -->23 October, 2017<!--webbot bot="Timestamp" endspan i-checksum="38510" --></p>
 
   <p><i>Copyright &copy; 2002 Samuel Krempp</i></p>
 

--- a/test/format_test2.cpp
+++ b/test/format_test2.cpp
@@ -11,6 +11,8 @@
 // ------------------------------------------------------------------------------
 
 #include "boost/format.hpp"
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/predef.h>
 
 #include <iostream> 
 #include <iomanip>
@@ -114,6 +116,23 @@ int test_main(int, char* [])
       cerr << s;
       BOOST_ERROR("formatting error. (flag 0)");
     }
+
+    // actually testing floating point output is implementation 
+    // specific so we're just going to do minimal checking...
+    double dbl = 1234567.890123f;
+
+#if __cplusplus >= 201103L || BOOST_VERSION_NUMBER_MAJOR(BOOST_COMP_MSVC) >= 12
+    // msvc-12.0 and later have support for hexfloat but do not set __cplusplus to a C++11 value
+    BOOST_CHECK(boost::starts_with((boost::format("%A") % dbl).str(), "0X"));
+    BOOST_CHECK(boost::starts_with((boost::format("%a") % dbl).str(), "0x"));
+#endif
+
+    BOOST_CHECK(boost::contains((boost::format("%E") % dbl).str(), "E"));
+    BOOST_CHECK(boost::contains((boost::format("%e") % dbl).str(), "e"));
+    BOOST_CHECK(boost::contains((boost::format("%F") % dbl).str(), "."));
+    BOOST_CHECK(boost::contains((boost::format("%f") % dbl).str(), "."));
+    BOOST_CHECK(!(boost::format("%G") % dbl).str().empty());
+    BOOST_CHECK(!(boost::format("%g") % dbl).str().empty());
 
     return 0;
 }


### PR DESCRIPTION
Using the format_matrix tool, I have ensured the only changes were for F, A, and a conversion specifiers.  I did a little grouping/prettying-up the conversion specifier switch statement in code as part of this PR.

Note that ``F`` versus ``f`` really only matters when using the float constants ``INFINITY`` or ``NAN``, however ``F`` is supported by ISO C99 so we're supporting it here as well.

With-Commit values are from msvc-14.1.

| String | Data | Pre-Commit | With-Commit |
| -: | :- | :- | :- | 
| ``%F`` | ``1234567.890123f`` | boost::bad_format_string: format-string is ill-formed | ``1234567.875000`` |
| ``%A`` | ``1234567.890123f`` | boost::bad_format_string: format-string is ill-formed | ``0X1.2D687EP+20`` |
| ``%a`` |   ``1234567.890123f`` | boost::bad_format_string: format-string is ill-formed | ``0x1.2d687ep+20`` |

This closes #30 