### PR TITLE
handle volatile arguments to operator% by making a non-volatile copy …

### DIFF
--- a/include/boost/format/format_class.hpp
+++ b/include/boost/format/format_class.hpp
@@ -68,6 +68,18 @@ namespace boost {
             { return io::detail::feed<CharT, Tr, Alloc, T&>(*this,x); }
 #endif
 
+        template<class T>
+        basic_format& operator%(volatile const T& x)
+            { /* make a non-volatile copy */ const T v(x);
+              /* pass the copy along      */ return io::detail::feed<CharT, Tr, Alloc, const T&>(*this, v); }
+
+#ifndef BOOST_NO_OVERLOAD_FOR_NON_CONST
+        template<class T>
+        basic_format& operator%(volatile T& x)
+            { /* make a non-volatile copy */ T v(x);
+              /* pass the copy along      */ return io::detail::feed<CharT, Tr, Alloc, T&>(*this, v); }
+#endif
+
 #if defined(__GNUC__)
         // GCC can't handle anonymous enums without some help
         // ** arguments passing ** //

--- a/test/format_test2.cpp
+++ b/test/format_test2.cpp
@@ -186,5 +186,9 @@ int test_main(int, char* [])
     BOOST_CHECK_THROW(boost::format("%I63d"), boost::io::bad_format_string);
     BOOST_CHECK_THROW(boost::format("%I128d"), boost::io::bad_format_string);
 
+    // issue-36 volatile keyword
+    volatile int vint = 1234567;
+    BOOST_CHECK_EQUAL((boost::format("%1%") % vint).str(), "1234567");
+
     return 0;
 }


### PR DESCRIPTION
…of them before feeding through