### PR TITLE
Removed deprecated std::allocator<void>

### DIFF
--- a/include/boost/format/alt_sstream_impl.hpp
+++ b/include/boost/format/alt_sstream_impl.hpp
@@ -255,10 +255,20 @@ namespace boost {
                 if(0 < add_size) {
                     new_size += add_size;
 #ifdef _RWSTD_NO_CLASS_PARTIAL_SPEC
+  #ifdef BOOST_NO_CXX11_ALLOCATOR
                     void *vdptr = alloc_.allocate(new_size, is_allocated_? oldptr : 0);
+  #else
+                    void *vdptr = std::allocator_traits<compat_allocator_type>::allocate(
+                        alloc_, new_size, is_allocated_? oldptr : 0);
+  #endif
                     newptr = static_cast<Ch *>(vdptr);
 #else
+  #ifdef BOOST_NO_CXX11_ALLOCATOR
                     newptr = alloc_.allocate(new_size, is_allocated_? oldptr : 0);
+  #else
+                    newptr = std::allocator_traits<compat_allocator_type>::allocate(
+                        alloc_, new_size, is_allocated_? oldptr : 0);
+  #endif
 #endif
                 }
 


### PR DESCRIPTION
Fix https://github.com/boostorg/format/issues/67

Based on patch from LibreOffice
https://cgit.freedesktop.org/libreoffice/core/commit/?id=677c8de4fa79cd9b278b142013ba7f1c9e4e41c3

and pull request from https://github.com/boostorg/bimap/pull/15