### PR TITLE
gcc10 C++20 fix removing allocate hint argument

### DIFF
--- a/include/boost/format/alt_sstream_impl.hpp
+++ b/include/boost/format/alt_sstream_impl.hpp
@@ -257,6 +257,8 @@ namespace boost {
 #ifdef _RWSTD_NO_CLASS_PARTIAL_SPEC
                     void *vdptr = alloc_.allocate(new_size, is_allocated_? oldptr : 0);
                     newptr = static_cast<Ch *>(vdptr);
+#elif (__cplusplus >= 201703L)
+                    newptr = alloc_.allocate(new_size);
 #else
                     newptr = alloc_.allocate(new_size, is_allocated_? oldptr : 0);
 #endif


### PR DESCRIPTION
The std::allocator<T>::allocate(n, hint) overload was deprecated in C++17 and removed in C++20 (https://en.cppreference.com/w/cpp/memory/allocator/allocate). This fix calls the single-argument allocate(n) function for C++17 and greater.