### PR TITLE
Fix to compile with Visual C++ 16.11 and /Zc:implicitNoexcept-.

### DIFF
--- a/include/boost/format/alt_sstream.hpp
+++ b/include/boost/format/alt_sstream.hpp
@@ -138,6 +138,7 @@ namespace boost {
             typedef basic_altstringbuf<Ch, Tr, Alloc>   stringbuf_t;
         public:
             typedef Alloc  allocator_type;
+            ~basic_oaltstringstream() noexcept override = default;
             basic_oaltstringstream() 
                 : pbase_type(new stringbuf_t), stream_t(pbase_type::member.get())
                 { }


### PR DESCRIPTION
Otherwise gets:
  Error C2694 'override': overriding virtual function
  has less restrictive exception specification than base
  class virtual member function 'base'

  Similar changes are being made e.g.:
    https://github.com/boostorg/json/pull/636

  And proposed here:
    https://github.com/boostorg/iostreams/pull/136

I grant there there could be more of this.
These two are just enough for our codebase.