### PR TITLE
C++11, Fix use of deprecated timer, fix group assignment operator.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -74,16 +74,16 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       B2_TOOLSET: msvc-12.0,msvc-14.0
 
-    - FLAVOR: Visual Studio 2008, 2010, 2012
+    - FLAVOR: Visual Studio 2010, 2012
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      B2_TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0
+      B2_TOOLSET: msvc-10.0,msvc-11.0
       B2_ADDRESS_MODEL: 32 # No 64bit support
 
     - FLAVOR: cygwin (32-bit)
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ADDPATH: C:\cygwin\bin;
       B2_ADDRESS_MODEL: 32
-      B2_CXXSTD: 03,11,14,1z
+      B2_CXXSTD: 11,14,1z
       B2_THREADING: threadapi=pthread
       B2_TOOLSET: gcc
 
@@ -91,7 +91,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       ADDPATH: C:\cygwin64\bin;
       B2_ADDRESS_MODEL: 64
-      B2_CXXSTD: 03,11,14,1z
+      B2_CXXSTD: 11,14,1z
       B2_THREADING: threadapi=pthread
       B2_TOOLSET: gcc
 
@@ -99,14 +99,14 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       B2_ADDRESS_MODEL: 32
       ADDPATH: C:\mingw\bin;
-      B2_CXXSTD: 03,11,14,1z
+      B2_CXXSTD: 11,14,1z
       B2_TOOLSET: gcc
 
     - FLAVOR: mingw64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       ADDPATH: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;
       B2_ADDRESS_MODEL: 64
-      B2_CXXSTD: 03,11,14,17,2a
+      B2_CXXSTD: 11,14,17,2a
       B2_TOOLSET: gcc
 
 install:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,49 +43,47 @@ jobs:
       matrix:
         include:
           # Linux, gcc
-          - { compiler: gcc-4.4,   cxxstd: '98,0x',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: gcc-4.6,   cxxstd: '03,0x',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: gcc-4.7,   cxxstd: '03,11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: gcc-4.8,   cxxstd: '03,11',          os: ubuntu-18.04 }
-          - { compiler: gcc-4.9,   cxxstd: '03,11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: gcc-5,     cxxstd: '03,11,14,1z',    os: ubuntu-18.04 }
-          - { compiler: gcc-6,     cxxstd: '03,11,14,17',    os: ubuntu-18.04 }
-          - { compiler: gcc-7,     cxxstd: '03,11,14,17',    os: ubuntu-18.04 }
-          - { compiler: gcc-8,     cxxstd: '03,11,14,17,2a', os: ubuntu-18.04 }
-          - { compiler: gcc-9,     cxxstd: '03,11,14,17,2a', os: ubuntu-18.04 }
-          - { compiler: gcc-10,    cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
-          - { compiler: gcc-11,    cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
+          - { compiler: gcc-4.7,   cxxstd: '11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: gcc-4.8,   cxxstd: '11',          os: ubuntu-18.04 }
+          - { compiler: gcc-4.9,   cxxstd: '11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: gcc-5,     cxxstd: '11,14,1z',    os: ubuntu-18.04 }
+          - { compiler: gcc-6,     cxxstd: '11,14,17',    os: ubuntu-18.04 }
+          - { compiler: gcc-7,     cxxstd: '11,14,17',    os: ubuntu-18.04 }
+          - { compiler: gcc-8,     cxxstd: '11,14,17,2a', os: ubuntu-18.04 }
+          - { compiler: gcc-9,     cxxstd: '11,14,17,2a', os: ubuntu-18.04 }
+          - { compiler: gcc-10,    cxxstd: '11,14,17,20', os: ubuntu-20.04 }
+          - { compiler: gcc-11,    cxxstd: '11,14,17,20', os: ubuntu-20.04 }
           - { name: GCC w/ sanitizers, sanitize: yes,
-              compiler: gcc-11,    cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
+              compiler: gcc-11,    cxxstd: '11,14,17,20', os: ubuntu-20.04 }
           - { name: Collect coverage, coverage: yes,
-              compiler: gcc-10,    cxxstd: '03,11',          os: ubuntu-20.04, install: 'g++-10-multilib', address-model: '32,64' }
+              compiler: gcc-10,    cxxstd: '11',          os: ubuntu-20.04, install: 'g++-10-multilib', address-model: '32,64' }
 
           # Linux, clang
-          - { compiler: clang-3.5, cxxstd: '03,11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.6, cxxstd: '03,11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.7, cxxstd: '03,11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.8, cxxstd: '03,11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
-          - { compiler: clang-3.9, cxxstd: '03,11,14',       os: ubuntu-18.04 }
-          - { compiler: clang-4.0, cxxstd: '03,11,14',       os: ubuntu-18.04 }
-          - { compiler: clang-5.0, cxxstd: '03,11,14,1z',    os: ubuntu-18.04 }
-          - { compiler: clang-6.0, cxxstd: '03,11,14,17',    os: ubuntu-18.04 }
-          - { compiler: clang-7,   cxxstd: '03,11,14,17',    os: ubuntu-18.04 }
+          - { compiler: clang-3.5, cxxstd: '11',          os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.6, cxxstd: '11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.7, cxxstd: '11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.8, cxxstd: '11,14',       os: ubuntu-20.04, container: 'ubuntu:16.04' }
+          - { compiler: clang-3.9, cxxstd: '11,14',       os: ubuntu-18.04 }
+          - { compiler: clang-4.0, cxxstd: '11,14',       os: ubuntu-18.04 }
+          - { compiler: clang-5.0, cxxstd: '11,14,1z',    os: ubuntu-18.04 }
+          - { compiler: clang-6.0, cxxstd: '11,14,17',    os: ubuntu-18.04 }
+          - { compiler: clang-7,   cxxstd: '11,14,17',    os: ubuntu-18.04 }
           # Note: clang-8 does not fully support C++20, so it is not compatible with some libstdc++ versions in this mode
-          - { compiler: clang-8,   cxxstd: '03,11,14,17,2a', os: ubuntu-18.04, install: 'clang-8 g++-7', gcc_toolchain: 7 }
-          - { compiler: clang-9,   cxxstd: '03,11,14,17,2a', os: ubuntu-20.04 }
-          - { compiler: clang-10,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
-          - { compiler: clang-11,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04 }
+          - { compiler: clang-8,   cxxstd: '11,14,17,2a', os: ubuntu-18.04, install: 'clang-8 g++-7', gcc_toolchain: 7 }
+          - { compiler: clang-9,   cxxstd: '11,14,17,2a', os: ubuntu-20.04 }
+          - { compiler: clang-10,  cxxstd: '11,14,17,20', os: ubuntu-20.04 }
+          - { compiler: clang-11,  cxxstd: '11,14,17,20', os: ubuntu-20.04 }
           - { name: Clang w/ valgrind, valgrind: yes,
-              compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04, install: 'valgrind' }
+              compiler: clang-12,  cxxstd: '11,14,17,20', os: ubuntu-20.04, install: 'valgrind' }
 
           # libc++
-          - { compiler: clang-6.0, cxxstd: '03,11,14',       os: ubuntu-18.04, stdlib: libc++, install: 'clang-6.0 libc++-dev libc++abi-dev' }
-          - { compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04, stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev' }
+          - { compiler: clang-6.0, cxxstd: '11,14',       os: ubuntu-18.04, stdlib: libc++, install: 'clang-6.0 libc++-dev libc++abi-dev' }
+          - { compiler: clang-12,  cxxstd: '11,14,17,20', os: ubuntu-20.04, stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev' }
           - { name: Clang w/ sanitizers, sanitize: yes,
-              compiler: clang-12,  cxxstd: '03,11,14,17,20', os: ubuntu-20.04, stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev' }
+              compiler: clang-12,  cxxstd: '11,14,17,20', os: ubuntu-20.04, stdlib: libc++, install: 'clang-12 libc++-12-dev libc++abi-12-dev' }
 
           # OSX, clang
-          - { compiler: clang,     cxxstd: '03,11,14,17,2a', os: macos-10.15, sanitize: yes }
+          - { compiler: clang,     cxxstd: '11,14,17,2a', os: macos-10.15, sanitize: yes }
 
           # Coverity Scan
           # requires two github secrets in repo to activate; see ci/github/coverity.sh
@@ -94,7 +92,7 @@ jobs:
               compiler: clang-10,  cxxstd: '17',             os: ubuntu-20.04, ccache: no }
 
           # multiarch (bigendian testing) - does not support coverage yet
-          # format has no endian compile-itme branches
+          # format has no endian compile-time branches so this is unnecessary
           # - { name: Big-endian, multiarch: yes,
           #     compiler: clang,     cxxstd: '17',             os: ubuntu-20.04, ccache: no, distro: fedora, edition: 34, arch: s390x }
 
@@ -131,13 +129,13 @@ jobs:
             fi
             git config --global pack.threads 0
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # For coverage builds fetch the whole history, else only 1 commit using a 'fake ternary'
           fetch-depth: ${{ matrix.coverage && '0' || '1' }}
 
       - name: Cache ccache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         if: env.B2_USE_CCACHE
         with:
           path: ~/.ccache
@@ -147,7 +145,7 @@ jobs:
             ${{matrix.os}}-${{matrix.container}}-${{matrix.compiler}}
 
       - name: Fetch Boost.CI
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: boostorg/boost-ci
           ref: master
@@ -227,9 +225,21 @@ jobs:
         if: '!matrix.coverity'
         run: ci/build.sh
 
-      - name: Upload coverage
+      - name: Collect coverage
         if: matrix.coverage
         run: ci/codecov.sh "upload"
+        env:
+          BOOST_CI_CODECOV_IO_UPLOAD: skip
+
+      - name: Upload coverage
+        if: matrix.coverage
+        uses: codecov/codecov-action@v4
+        with:
+          disable_search: true
+          file: coverage.info
+          name: Github Actions
+          token: ${{secrets.CODECOV_TOKEN}}
+          verbose: true
 
       - name: Run coverity
         if: matrix.coverity && github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'master')
@@ -249,15 +259,15 @@ jobs:
           - { toolset: msvc-14.2, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2019 }
           - { name: Collect coverage, coverage: yes,
               toolset: msvc-14.3, cxxstd: '14,17,20',       addrmd: '32,64', os: windows-2022 }
-          - { toolset: gcc,       cxxstd: '03,11,14,17,2a', addrmd: '64',    os: windows-2019 }
+          - { toolset: gcc,       cxxstd: '11,14,17,2a',    addrmd: '64',    os: windows-2019 }
 
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Fetch Boost.CI
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: boostorg/boost-ci
           ref: master
@@ -279,7 +289,7 @@ jobs:
           B2_CXXSTD: ${{matrix.cxxstd}}
           B2_ADDRESS_MODEL: ${{matrix.addrmd}}
 
-      - name: Run coverage
+      - name: Collect coverage
         shell: powershell
         if: matrix.coverage
         run: ci\opencppcoverage.ps1
@@ -290,9 +300,13 @@ jobs:
 
       - name: Upload coverage
         if: matrix.coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
-          files: __out/cobertura.xml
+          disable_search: true
+          file: __out/cobertura.xml
+          name: Github Actions
+          token: ${{secrets.CODECOV_TOKEN}}
+          verbose: true
 
   CMake:
     defaults:
@@ -312,10 +326,10 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Fetch Boost.CI
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: boostorg/boost-ci
           ref: master

--- a/Jamfile
+++ b/Jamfile
@@ -5,19 +5,29 @@
 #  Use, modification, and distribution are subject to the
 #  Boost Software License, Version 1.0. (See accompanying file
 #  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+# desired, but...
+# gcc.compile.c++ bin.v2/libs/format/test/format_test1.test/gcc-10/debug/x86_64/cxxstd-03-iso/threading-multi/visibility-hidden/format_test1.o
+# In file included from ./boost/preprocessor/facilities/overload.hpp:17,
+#                  from ./boost/preprocessor/tuple/elem.hpp:21,
+#                  from ./boost/preprocessor/array/data.hpp:16,
+#                  from ./boost/preprocessor/array/elem.hpp:15,
+#                  from ./boost/preprocessor/iteration/iterate.hpp:17,
+#                  from ./boost/utility/result_of.hpp:31,
+#                  from ./boost/optional/optional.hpp:63,
+#                  from ./boost/optional.hpp:15,
+#                  from ./boost/format/internals.hpp:21,
+#                  from ./boost/format.hpp:38,
+#                  from libs/format/test/format_test1.cpp:14:
+# ./boost/preprocessor/variadic/size.hpp:48:39: error: anonymous variadic macros were introduced in C++11 [-Werror=variadic-macros]
+#    48 | #       define BOOST_PP_VARIADIC_SIZE(...) BOOST_PP_VARIADIC_DO_SIZE(__VA_ARGS__)
+#       |                                       ^~~
+#
+#       <warnings-as-errors>on
 
 project
     : requirements
-
-      <warnings>all
-
-      <toolset>clang:<cxxflags>-Wextra
-      <toolset>clang:<cxxflags>-ansi
-      <toolset>clang:<cxxflags>-pedantic
-
-      <toolset>gcc:<cxxflags>-Wextra
-      <toolset>gcc:<cxxflags>-ansi
-      <toolset>gcc:<cxxflags>-pedantic
+        <warnings>pedantic
     ;
 
 # please order by name to ease maintenance

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Distributed under the [Boost Software License, Version 1.0](http://www.boost.org
 
 ### Properties
 
-* C++03
+* C++11
 * Header-only
 
 ### Build Status

--- a/benchmark/Jamfile
+++ b/benchmark/Jamfile
@@ -13,15 +13,18 @@ project libs/format/benchmark
 
 exe bench_format_no_locale
     : bench_format.cpp
+      /boost/timer//boost_timer
     : <define>BOOST_NO_STD_LOCALE <location-prefix>no_locale    
     ;
 
 exe bench_format_normal
     : bench_format.cpp 
+      /boost/timer//boost_timer
     : <location-prefix>normal
     ;
 
 exe bench_format_no_reuse_stream
     : bench_format.cpp
+      /boost/timer//boost_timer
     : <include>alts <define>BOOST_FORMAT_NO_OSS_MEMBER <location-prefix>no_reuse_stream
     ;

--- a/benchmark/bench_format.cpp
+++ b/benchmark/bench_format.cpp
@@ -28,7 +28,7 @@
 #include <cstring>
 #include <fstream>
 #include <cmath>   // floor
-#include <boost/timer.hpp>
+#include <boost/timer/timer.hpp>
 #include <vector>
 
 #include <boost/format.hpp>
@@ -87,7 +87,7 @@ static int NTests = 300000;
 
 //static std::stringstream nullStream;
 static NulStream nullStream;
-static double tstream, tpf;
+static boost::timer::nanosecond_type tstream, tpf;
 //static const std::string fstring="%3$#x %1$20.10E %2$g %3$d \n";
 static const std::string fstring="%3$0#6x %1$20.10E %2$g %3$0+5d \n";
 static const double     arg1=45.23;
@@ -120,11 +120,11 @@ void test_sprintf()
       cerr << endl << buf;
     }
     // time the loop :
-    boost::timer chrono;
+    boost::timer::cpu_timer chrono;
     for(int i=0; i<NTests; ++i) {
       sprintf(buf, fstring.c_str(), arg1, arg2, arg3);
     }
-    tpf=chrono.elapsed();
+    tpf=chrono.elapsed().wall;
     cout  << left << setw(20) <<"printf time"<< right <<":" << tpf  << endl;
 }
 
@@ -133,12 +133,12 @@ void test_try1()
   using namespace std;
   boost::io::basic_oaltstringstream<char> oss;
   oss << boost::format(fstring) % arg1 % arg2 % arg3;
-  boost::timer chrono;
+  boost::timer::cpu_timer chrono;
   size_t dummy=0;
   for(int i=0; i<NTests; ++i) {
       dummy += oss.cur_size();
   }
-  double t = chrono.elapsed();
+  boost::timer::nanosecond_type t = chrono.elapsed().wall;
   cout  << left << setw(20) <<"try1 time"<< right <<":" << setw(5) << t
         << ",  = " << t / tpf << " * printf "
         << ",  = " << t / tstream << " * nullStream \n";
@@ -155,12 +155,12 @@ void test_try2()
   oss.clear_buffer();
   oss << s << s;
   s = oss.cur_str();
-  boost::timer chrono;
+  boost::timer::cpu_timer chrono;
   size_t dummy=0;
   for(int i=0; i<NTests; ++i) {
       dummy += oss.cur_size();
   }
-  double t = chrono.elapsed();
+  boost::timer::nanosecond_type t = chrono.elapsed().wall;
   cout  << left << setw(20) <<"try2 time"<< right <<":" << setw(5) << t
         << ",  = " << t / tpf << " * printf "
         << ",  = " << t / tstream << " * nullStream \n";
@@ -183,7 +183,7 @@ void do_stream(std::ostream& os) {
 void test_nullstream()
 {
     using namespace std;
-    boost::timer chrono;
+    boost::timer::cpu_timer chrono;
     boost::io::basic_oaltstringstream<char> oss;
 
     {   
@@ -207,7 +207,7 @@ void test_nullstream()
 //       nullStream << " " << arg2 << " " << arg3 << " \n" ;
 
 //     }
-    double t = chrono.elapsed();
+    boost::timer::nanosecond_type t = chrono.elapsed().wall;
     cout  << left << setw(20) <<"ostream time"<< right <<":" << setw(5) << t  
           << ",  = " << t / tpf << " * printf \n";
     tstream = t;
@@ -216,7 +216,7 @@ void test_nullstream()
 void test_opti_nullstream()
 {
     using namespace std;
-    boost::timer chrono;
+    boost::timer::cpu_timer chrono;
     boost::io::basic_oaltstringstream<char> oss;
     //static const std::string fstring="%3$#x %1$20.10E %2$g %3$d \n";
 
@@ -251,7 +251,7 @@ void test_opti_nullstream()
       nullStream.flags(f0); nullStream.precision(p0);
       nullStream << " " << arg2 << " " << arg3 << " \n" ;
     }
-    double t = chrono.elapsed();
+    boost::timer::nanosecond_type t = chrono.elapsed().wall;
     cout  << left << setw(20) <<"opti-stream time"<< right <<":" << setw(5) << t  
           << ",  = " << t / tpf << " * printf \n";
     //    tstream = t;
@@ -271,11 +271,11 @@ void test_parsed_once_format()
     // not only is the format-string parsed once,
     // but also the buffer of the internal stringstream is already allocated.
 
-    boost::timer chrono;        
+    boost::timer::cpu_timer chrono;        
     for(int i=0; i<NTests; ++i) {
         nullStream << boost::format(fmter) % arg1 % arg2 % arg3;
     }
-    double t=chrono.elapsed();
+    boost::timer::nanosecond_type t=chrono.elapsed().wall;
     cout  << left << setw(20) <<"parsed-once time"<< right <<":" << setw(5) << t 
           << ",  = " << t / tpf << " * printf "
           << ",  = " << t / tstream << " * nullStream \n";
@@ -290,12 +290,12 @@ void test_reused_format()
     cerr << endl << oss.str();
   }
 
-  boost::timer chrono;
+  boost::timer::cpu_timer chrono;
   boost::format fmter;
   for(int i=0; i<NTests; ++i) {
     nullStream << fmter.parse(fstring) % arg1 % arg2 % arg3;
   }
-  double t = chrono.elapsed();
+  boost::timer::nanosecond_type t = chrono.elapsed().wall;
   cout  << left << setw(20) <<"reused format time"<< right <<":" << setw(5) << t
         << ",  = " << t / tpf << " * printf "
         << ",  = " << t / tstream << " * nullStream \n";
@@ -310,11 +310,11 @@ void test_format()
     cerr << endl << oss.str();
   }
 
-  boost::timer chrono;
+  boost::timer::cpu_timer chrono;
   for(int i=0; i<NTests; ++i) {
     nullStream << boost::format(fstring) % arg1 % arg2 % arg3;
   }
-  double t = chrono.elapsed();
+  boost::timer::nanosecond_type t = chrono.elapsed().wall;
   cout  << left << setw(20) <<"format time"<< right <<":" << setw(5) << t
         << ",  = " << t / tpf << " * printf "
         << ",  = " << t / tstream << " * nullStream \n";

--- a/include/boost/format/group.hpp
+++ b/include/boost/format/group.hpp
@@ -34,9 +34,15 @@ namespace detail {
 
 
 // empty group, but useful even though.
-struct group0 
+struct group0
 {
-    group0()      {}
+    BOOST_FORCEINLINE group0() {}
+#if !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+    group0& operator=(const group0&) = delete;
+#else
+private:
+    group0& operator=(const group0&);
+#endif
 };
 
 template <class Ch, class Tr>
@@ -49,14 +55,12 @@ operator << ( BOOST_IO_STD basic_ostream<Ch, Tr>& os,
 }
 
 template <class T1>
-struct group1
+struct group1 : group0
 {
     T1 a1_;
-    group1(T1 a1)
-      : a1_(a1)
+    BOOST_FORCEINLINE group1(T1 a1)
+      : group0(), a1_(a1)
       {}
-private:
-   group1& operator=(const group1&);
 };
 
 template <class Ch, class Tr, class T1>
@@ -73,15 +77,12 @@ operator << (BOOST_IO_STD basic_ostream<Ch, Tr>& os,
 
 
 template <class T1,class T2>
-struct group2
+struct group2 : group1<T1>
 {
-    T1 a1_;
     T2 a2_;
-    group2(T1 a1,T2 a2)
-      : a1_(a1),a2_(a2)
+    BOOST_FORCEINLINE group2(T1 a1, T2 a2)
+      : group1<T1>(a1), a2_(a2)
       {}
-private:
-   group2& operator=(const group2&);
 };
 
 template <class Ch, class Tr, class T1,class T2>
@@ -95,16 +96,12 @@ operator << (BOOST_IO_STD basic_ostream<Ch, Tr>& os,
 }
 
 template <class T1,class T2,class T3>
-struct group3
+struct group3 : group2<T1, T2>
 {
-    T1 a1_;
-    T2 a2_;
     T3 a3_;
-    group3(T1 a1,T2 a2,T3 a3)
-      : a1_(a1),a2_(a2),a3_(a3)
+    BOOST_FORCEINLINE group3(T1 a1,T2 a2,T3 a3)
+      : group2<T1, T2>(a1, a2), a3_(a3)
       {}
-private:
-   group3& operator=(const group3&);
 };
 
 template <class Ch, class Tr, class T1,class T2,class T3>
@@ -118,17 +115,12 @@ operator << (BOOST_IO_STD basic_ostream<Ch, Tr>& os,
 }
 
 template <class T1,class T2,class T3,class T4>
-struct group4
+struct group4 : group3<T1, T2, T3>
 {
-    T1 a1_;
-    T2 a2_;
-    T3 a3_;
     T4 a4_;
-    group4(T1 a1,T2 a2,T3 a3,T4 a4)
-      : a1_(a1),a2_(a2),a3_(a3),a4_(a4)
+    BOOST_FORCEINLINE group4(T1 a1,T2 a2,T3 a3,T4 a4)
+      : group3<T1, T2, T3>(a1, a2, a3), a4_(a4)
       {}
-private:
-   group4& operator=(const group4&);
 };
 
 template <class Ch, class Tr, class T1,class T2,class T3,class T4>
@@ -142,15 +134,11 @@ operator << (BOOST_IO_STD basic_ostream<Ch, Tr>& os,
 }
 
 template <class T1,class T2,class T3,class T4,class T5>
-struct group5
+struct group5 : group4<T1, T2, T3, T4>
 {
-    T1 a1_;
-    T2 a2_;
-    T3 a3_;
-    T4 a4_;
     T5 a5_;
-    group5(T1 a1,T2 a2,T3 a3,T4 a4,T5 a5)
-      : a1_(a1),a2_(a2),a3_(a3),a4_(a4),a5_(a5)
+    BOOST_FORCEINLINE group5(T1 a1,T2 a2,T3 a3,T4 a4,T5 a5)
+      : group4<T1, T2, T3, T4>(a1, a2, a3, a4), a5_(a5)
       {}
 };
 
@@ -165,16 +153,11 @@ operator << (BOOST_IO_STD basic_ostream<Ch, Tr>& os,
 }
 
 template <class T1,class T2,class T3,class T4,class T5,class T6>
-struct group6
+struct group6 : group5<T1, T2, T3, T4, T5>
 {
-    T1 a1_;
-    T2 a2_;
-    T3 a3_;
-    T4 a4_;
-    T5 a5_;
     T6 a6_;
-    group6(T1 a1,T2 a2,T3 a3,T4 a4,T5 a5,T6 a6)
-      : a1_(a1),a2_(a2),a3_(a3),a4_(a4),a5_(a5),a6_(a6)
+    BOOST_FORCEINLINE group6(T1 a1,T2 a2,T3 a3,T4 a4,T5 a5,T6 a6)
+      : group5<T1, T2, T3, T4, T5>(a1, a2, a3, a4, a5), a6_(a6)
       {}
 };
 
@@ -189,17 +172,11 @@ operator << (BOOST_IO_STD basic_ostream<Ch, Tr>& os,
 }
 
 template <class T1,class T2,class T3,class T4,class T5,class T6,class T7>
-struct group7
+struct group7 : group6<T1, T2, T3, T4, T5, T6>
 {
-    T1 a1_;
-    T2 a2_;
-    T3 a3_;
-    T4 a4_;
-    T5 a5_;
-    T6 a6_;
     T7 a7_;
-    group7(T1 a1,T2 a2,T3 a3,T4 a4,T5 a5,T6 a6,T7 a7)
-      : a1_(a1),a2_(a2),a3_(a3),a4_(a4),a5_(a5),a6_(a6),a7_(a7)
+    BOOST_FORCEINLINE group7(T1 a1,T2 a2,T3 a3,T4 a4,T5 a5,T6 a6,T7 a7)
+      : group6<T1, T2, T3, T4, T5, T6>(a1, a2, a3, a4, a5, a6), a7_(a7)
       {}
 };
 
@@ -214,18 +191,11 @@ operator << (BOOST_IO_STD basic_ostream<Ch, Tr>& os,
 }
 
 template <class T1,class T2,class T3,class T4,class T5,class T6,class T7,class T8>
-struct group8
+struct group8 : group7<T1, T2, T3, T4, T5, T6, T7>
 {
-    T1 a1_;
-    T2 a2_;
-    T3 a3_;
-    T4 a4_;
-    T5 a5_;
-    T6 a6_;
-    T7 a7_;
     T8 a8_;
-    group8(T1 a1,T2 a2,T3 a3,T4 a4,T5 a5,T6 a6,T7 a7,T8 a8)
-      : a1_(a1),a2_(a2),a3_(a3),a4_(a4),a5_(a5),a6_(a6),a7_(a7),a8_(a8)
+    BOOST_FORCEINLINE group8(T1 a1,T2 a2,T3 a3,T4 a4,T5 a5,T6 a6,T7 a7,T8 a8)
+      : group7<T1, T2, T3, T4, T5, T6, T7>(a1, a2, a3, a4, a5, a6, a7), a8_(a8)
       {}
 };
 
@@ -240,19 +210,11 @@ operator << (BOOST_IO_STD basic_ostream<Ch, Tr>& os,
 }
 
 template <class T1,class T2,class T3,class T4,class T5,class T6,class T7,class T8,class T9>
-struct group9
+struct group9 : group8<T1, T2, T3, T4, T5, T6, T7, T8>
 {
-    T1 a1_;
-    T2 a2_;
-    T3 a3_;
-    T4 a4_;
-    T5 a5_;
-    T6 a6_;
-    T7 a7_;
-    T8 a8_;
     T9 a9_;
-    group9(T1 a1,T2 a2,T3 a3,T4 a4,T5 a5,T6 a6,T7 a7,T8 a8,T9 a9)
-      : a1_(a1),a2_(a2),a3_(a3),a4_(a4),a5_(a5),a6_(a6),a7_(a7),a8_(a8),a9_(a9)
+    BOOST_FORCEINLINE group9(T1 a1,T2 a2,T3 a3,T4 a4,T5 a5,T6 a6,T7 a7,T8 a8,T9 a9)
+      : group8<T1, T2, T3, T4, T5, T6, T7, T8>(a1, a2, a3, a4, a5, a6, a7, a8), a9_(a9)
       {}
 };
 
@@ -267,20 +229,11 @@ operator << (BOOST_IO_STD basic_ostream<Ch, Tr>& os,
 }
 
 template <class T1,class T2,class T3,class T4,class T5,class T6,class T7,class T8,class T9,class T10>
-struct group10
+struct group10 : group9<T1, T2, T3, T4, T5, T6, T7, T8, T9>
 {
-    T1 a1_;
-    T2 a2_;
-    T3 a3_;
-    T4 a4_;
-    T5 a5_;
-    T6 a6_;
-    T7 a7_;
-    T8 a8_;
-    T9 a9_;
     T10 a10_;
-    group10(T1 a1,T2 a2,T3 a3,T4 a4,T5 a5,T6 a6,T7 a7,T8 a8,T9 a9,T10 a10)
-      : a1_(a1),a2_(a2),a3_(a3),a4_(a4),a5_(a5),a6_(a6),a7_(a7),a8_(a8),a9_(a9),a10_(a10)
+    BOOST_FORCEINLINE group10(T1 a1,T2 a2,T3 a3,T4 a4,T5 a5,T6 a6,T7 a7,T8 a8,T9 a9,T10 a10)
+      : group9<T1, T2, T3, T4, T5, T6, T7, T8, T9>(a1, a2, a3, a4, a5, a6, a7, a8, a9), a10_(a10)
       {}
 };
 


### PR DESCRIPTION
Dependencies like smart_ptr will no longer support C++03 therefore
the new minimum language level is C++11, and all the CI jobs for
both C++03 and C++98 have been removed.
    
Fixed use of the deprecated top level timer class as it was causing
build problems (warnings-as-errors).
    
Fixed -Werror=deprecated-cast in group.hpp.
    
These changes also allow b2 to work properly when executed from
within the format directory.