### PR TITLE
cmake: Also build the test programs in BUILD_TESTING=Y mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,17 @@ target_compile_features(boost_format INTERFACE cxx_std_11)
 
 if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
 
-  add_subdirectory(test)
+  if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+
+    message(STATUS "Using CMake version ${CMAKE_VERSION}")
+
+    set(Boost_DEBUG ON)
+    find_package(Boost 1.85 CONFIG REQUIRED COMPONENTS assert config core optional smart_ptr throw_exception utility)
+
+  endif()
+
+  # Follow the Boost convention: don't build test targets by default,
+  # and only when explicitly requested by building target tests
+  add_subdirectory(test EXCLUDE_FROM_ALL)
 
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.8...3.20)
+
+add_executable(format_test1 format_test1.cpp)
+target_link_libraries(format_test1 Boost::format)
+
+add_executable(format_test2 format_test2.cpp)
+target_link_libraries(format_test2 Boost::format)
+
+add_executable(format_test3 format_test3.cpp)
+target_link_libraries(format_test3 Boost::format)
+
+add_executable(format_test_enum format_test_enum.cpp)
+target_link_libraries(format_test_enum Boost::format)
+
+add_executable(format_test_exceptions format_test_exceptions.cpp)
+target_link_libraries(format_test_exceptions Boost::format)
+
+add_executable(format_test_wstring format_test_wstring.cpp)
+target_link_libraries(format_test_wstring Boost::format)


### PR DESCRIPTION
Extending the cmake build to also build the test programs.

Requires `BUILD_TESTING` mode and an installed boost that cmake can find via find_package.
Also requires using the `tests/all` ninja target.

Ideally this test coverage could be adapted as cmake tests, but this is the first step.

```
$ /opt/cmake-4.1.1-linux-x86_64/bin/cmake -G Ninja -DCMAKE_CXX_COMPILER=g++-14 .. -DBUILD_TESTING=Y
-- The CXX compiler identification is GNU 14.3.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/g++-14 - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Using CMake version 4.1.1
-- Found Boost 1.90.0 at /opt/boost-1.90.0/lib/cmake/Boost-1.90.0
--   Requested configuration: REQUIRED COMPONENTS assert;config;core;optional;smart_ptr;throw_exception;utility
-- BoostConfig: find_package(boost_headers 1.90.0 EXACT CONFIG REQUIRED  HINTS /opt/boost-1.90.0/lib/cmake)
-- Found boost_headers 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_headers-1.90.0
-- BoostConfig: find_package(boost_assert 1.90.0 EXACT CONFIG REQUIRED  HINTS /opt/boost-1.90.0/lib/cmake)
-- Found boost_assert 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_assert-1.90.0
-- Found boost_config 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_config-1.90.0
-- BoostConfig: find_package(boost_config 1.90.0 EXACT CONFIG REQUIRED  HINTS /opt/boost-1.90.0/lib/cmake)
-- Found boost_config 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_config-1.90.0
-- BoostConfig: find_package(boost_core 1.90.0 EXACT CONFIG REQUIRED  HINTS /opt/boost-1.90.0/lib/cmake)
-- Found boost_core 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_core-1.90.0
-- Found boost_throw_exception 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_throw_exception-1.90.0
-- BoostConfig: find_package(boost_optional 1.90.0 EXACT CONFIG REQUIRED  HINTS /opt/boost-1.90.0/lib/cmake)
-- Found boost_optional 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_optional-1.90.0
-- Found boost_type_traits 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_type_traits-1.90.0
-- Found boost_static_assert 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_static_assert-1.90.0
-- BoostConfig: find_package(boost_smart_ptr 1.90.0 EXACT CONFIG REQUIRED  HINTS /opt/boost-1.90.0/lib/cmake)
-- Found boost_smart_ptr 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_smart_ptr-1.90.0
-- BoostConfig: find_package(boost_throw_exception 1.90.0 EXACT CONFIG REQUIRED  HINTS /opt/boost-1.90.0/lib/cmake)
-- Found boost_throw_exception 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_throw_exception-1.90.0
-- BoostConfig: find_package(boost_utility 1.90.0 EXACT CONFIG REQUIRED  HINTS /opt/boost-1.90.0/lib/cmake)
-- Found boost_utility 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_utility-1.90.0
-- Found boost_io 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_io-1.90.0
-- Found boost_preprocessor 1.90.0 at /opt/boost-1.90.0/lib/cmake/boost_preprocessor-1.90.0
-- Configuring done (0.1s)
-- Generating done (0.0s)
-- Build files have been written to: /home/nigels/dev/format/build
```